### PR TITLE
Fixed failure to validate personummer ending with 0

### DIFF
--- a/src/main/java/Personnummer.java
+++ b/src/main/java/Personnummer.java
@@ -12,7 +12,7 @@ public final class Personnummer {
     private static final Pattern regexPattern;
 
     static {
-        regexPattern = Pattern.compile("(\\d{2}){0,1}(\\d{2})(\\d{2})(\\d{2})([-|+]{0,1})?(\\d{3})(\\d{0,1})");
+        regexPattern = Pattern.compile("(\\d{2})?(\\d{2})(\\d{2})(\\d{2})([-|+]?)?(\\d{3})(\\d?)");
     }
 
     /**
@@ -64,19 +64,19 @@ public final class Personnummer {
         // passed value. The checksum is returned and tested against the control number
         // in the social security number to make sure that it is a valid number.
 
-        int sum = 0;
         int temp;
+        int sum = 0;
 
-        for (int i=value.length();i-->0;) {
-            temp = value.charAt(i) - 48;
-            sum += (i % 2 == 0) ? ((temp *= 2) > 9 ? temp - 9 : temp) : temp;
+        for (int i = 0; i < value.length(); i++) {
+            temp = Character.getNumericValue(value.charAt(i));
+            temp *= 2 - (i % 2);
+            if (temp > 9)
+                temp -= 9;
+
+            sum += temp;
         }
 
-        if (sum != 0) {
-            sum = 10 - (sum % 10);
-        }
-
-        return sum;
+        return (int)(Math.ceil((double)sum / 10.0) * 10.0 - (double)sum);
     }
 
     private static boolean testDate(int year, int month, int day) {

--- a/src/test/java/PersonnummerTest.java
+++ b/src/test/java/PersonnummerTest.java
@@ -13,6 +13,7 @@ public class PersonnummerTest {
         assertTrue(Personnummer.valid("196408233234"));
         assertTrue(Personnummer.valid("0001010107"));
         assertTrue(Personnummer.valid("000101-0107"));
+        assertTrue(Personnummer.valid("1010101010"));
         assertTrue(Personnummer.valid(6403273813L));
         assertTrue(Personnummer.valid(5108189167L));
         assertTrue(Personnummer.valid(199001010017L));


### PR DESCRIPTION
This library used to fail validating a valid personnummer ending with '0', now it doesn't.