### PR TITLE
Removal of Oracle JDK.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ jdk:
   - openjdk10
   - openjdk11
   - openjdk12
-  - openjdk13
-  - openjdk14
 cache:
   directories:
     - $HOME/.gradle

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,7 @@ language: java
 os:
   - linux
 jdk:
-  - oraclejdk8
-  - oraclejdk9
-  - openjdk8
   - openjdk11
-  - oraclejdk11
   - openjdk12
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,13 @@ language: java
 os:
   - linux
 jdk:
+  - openjdk8
+  - openjdk9
+  - openjdk10
   - openjdk11
   - openjdk12
+  - openjdk13
+  - openjdk14
 cache:
   directories:
     - $HOME/.gradle


### PR DESCRIPTION
* Removed Oracle JDK from the test matrix.
* Added openJDK 9 and 10 to the matrix.

Fixes #13 