### PR TITLE
Removing broken method valid(long n):

### DIFF
--- a/src/main/java/Personnummer.java
+++ b/src/main/java/Personnummer.java
@@ -53,16 +53,6 @@ public final class Personnummer {
         return (luhn == control) && (testDate(year, month, day) || testDate(year, month, day - 60));
     }
 
-    /**
-     * Validate a Swedish social security number.
-     *
-     * @param value Social security number to validate, as long.
-     * @return True if valid.
-     */
-    public static boolean valid(long value) {
-        return valid(Long.toString(value));
-    }
-
     private static int luhn(String value) {
         // Luhn/mod10 algorithm. Used to calculate a checksum from the
         // passed value. The checksum is returned and tested against the control number

--- a/src/test/java/PersonnummerTest.java
+++ b/src/test/java/PersonnummerTest.java
@@ -14,19 +14,10 @@ public class PersonnummerTest {
         assertTrue(Personnummer.valid("0001010107"));
         assertTrue(Personnummer.valid("000101-0107"));
         assertTrue(Personnummer.valid("1010101010"));
-        assertTrue(Personnummer.valid(6403273813L));
-        assertTrue(Personnummer.valid(5108189167L));
-        assertTrue(Personnummer.valid(199001010017L));
-        assertTrue(Personnummer.valid(191304012931L));
-        assertTrue(Personnummer.valid(196408233234L));
     }
 
     @Test
     public void testWithoutControlDigit() {
-        assertFalse(Personnummer.valid(640327381L));
-        assertFalse(Personnummer.valid(510818916L));
-        assertFalse(Personnummer.valid(19900101001L));
-        assertFalse(Personnummer.valid(100101001L));
         assertFalse(Personnummer.valid("640327-381"));
         assertFalse(Personnummer.valid("510818-916"));
         assertFalse(Personnummer.valid("19900101-001"));
@@ -46,14 +37,10 @@ public class PersonnummerTest {
     public void testCoordinationNumbers() {
         assertTrue(Personnummer.valid("701063-2391"));
         assertTrue(Personnummer.valid("640883-3231"));
-        assertTrue(Personnummer.valid(7010632391L));
-        assertTrue(Personnummer.valid(6408833231L));
     }
 
     @Test
     public void testWithBadCoordinationNumbers() {
-        assertFalse(Personnummer.valid(9001610017L));
-        assertFalse(Personnummer.valid(6408933231L));
         assertFalse(Personnummer.valid("900161-0017"));
         assertFalse(Personnummer.valid("640893-3231"));
     }


### PR DESCRIPTION
The `boolean valid(long value)` method as defined in the spec is, IMHO, flawed.

Valid personal numbers that begin with `00` (people born in 2000 and later) does not work with this method. 
**For example:**
 `001224-4919` is a valid number (18 year old male born 2000-12-24).

`valid(l001224-4919L)` - (`long`) returns false
`valid("001224-4919")` (`String`) returns true

Behaviour is inconsistent. This commit removes the method and its associated unit tests.