### PR TITLE
hotfix: Regex allowing | (pipe).

### DIFF
--- a/src/main/java/dev/personnummer/Personnummer.java
+++ b/src/main/java/dev/personnummer/Personnummer.java
@@ -15,7 +15,7 @@ public final class Personnummer implements Comparable<Personnummer> {
     private static final Pattern regexPattern;
 
     static {
-        regexPattern = Pattern.compile("^(\\d{2})?(\\d{2})(\\d{2})(\\d{2})([-|+]?)?((?!000)\\d{3})(\\d?)$");
+        regexPattern = Pattern.compile("^(\\d{2})?(\\d{2})(\\d{2})(\\d{2})([-+]?)?((?!000)\\d{3})(\\d?)$");
     }
 
     /**

--- a/src/test/java/PersonnummerTest.java
+++ b/src/test/java/PersonnummerTest.java
@@ -37,10 +37,10 @@ public class PersonnummerTest {
     @ParameterizedTest
     @MethodSource({"DataProvider#getInvalidPersonnummer", "DataProvider#getValidCoordinationNumbers"})
     public void testConstructorInvalid(PersonnummerData ssn) {
-        assertThrows(PersonnummerException.class, () -> new Personnummer(ssn.longFormat, new Options(false)));
-        assertThrows(PersonnummerException.class, () -> new Personnummer(ssn.shortFormat, new Options(false)));
-        assertThrows(PersonnummerException.class, () -> new Personnummer(ssn.separatedFormat, new Options(false)));
-        assertThrows(PersonnummerException.class, () -> new Personnummer(ssn.separatedFormat, new Options(false)));
+        assertThrows(PersonnummerException.class, () -> new Personnummer(ssn.longFormat, new Options(false)), ssn.longFormat);
+        assertThrows(PersonnummerException.class, () -> new Personnummer(ssn.shortFormat, new Options(false)), ssn.shortFormat);
+        assertThrows(PersonnummerException.class, () -> new Personnummer(ssn.separatedFormat, new Options(false)), ssn.separatedFormat);
+        assertThrows(PersonnummerException.class, () -> new Personnummer(ssn.separatedLong, new Options(false)), ssn.separatedLong);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Signed-off-by: Johannes Tegnér <johannes@jitesoft.com>

**Type of change**

- [ ] New feature
- [X] Bug fix
- [ ] Security patch
- [ ] Documentation update

**Description**

Updated regexp to no longer accept `|` as a separator.

**Related issue**

#50 

**Motivation**

<!-- Why should we accept this pull request? :) -->

**Checklist**

- [X] I have read the **CONTRIBUTING** document.
- [X] I have read and accepted the **Code of conduct**
- [X] Tests passes.
- [X] Style lints passes.
