### PR TITLE
Hotfix: Leap year should throw exception.

### DIFF
--- a/src/main/java/dev/personnummer/Personnummer.java
+++ b/src/main/java/dev/personnummer/Personnummer.java
@@ -1,9 +1,8 @@
 package dev.personnummer;
 
+import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
 import java.util.Objects;
 import java.util.regex.*;
 
@@ -157,9 +156,10 @@ public final class Personnummer implements Comparable<Personnummer> {
         this.controlNumber = matches.group(7);
 
         try {
-            DateTimeFormatter.ofPattern("yyyy MM dd").parse(String.format("%s %s %02d", this.fullYear, this.month, this.realDay));
-        } catch (DateTimeParseException e) {
-            throw new PersonnummerException("Invalid personal identity number.");
+            //noinspection ResultOfMethodCallIgnored
+            LocalDate.of(Integer.parseInt(this.fullYear), Integer.parseInt(this.month), this.realDay);
+        } catch (DateTimeException e) {
+            throw new PersonnummerException("Invalid personal identity number: " + e.getMessage());
         }
 
         this.isMale =  Integer.parseInt(Character.toString(this.numbers.charAt(2))) % 2 == 1;
@@ -191,7 +191,7 @@ public final class Personnummer implements Comparable<Personnummer> {
 	public String toString() {
 		return format();
 	}
-	
+
 	/**
 	 *  get a DateTime object from the Peronnummer object's date values of Date Month and Time.
 	 * @return DateTime object from the personnummer object

--- a/src/test/java/PersonnummerTest.java
+++ b/src/test/java/PersonnummerTest.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import dev.personnummer.*;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
@@ -231,4 +232,11 @@ public class PersonnummerTest {
         assertThrows(PersonnummerException.class, () -> Personnummer.parse(ssn.separatedFormat, new Options(false)));
     }
 
+    @Test
+    void testLeapYear() {
+        assertEquals(
+                "Invalid personal identity number: Invalid date 'February 29' as '1985' is not a leap year",
+                assertThrows(PersonnummerException.class, () -> Personnummer.parse("8502291234")).getMessage()
+        );
+    }
 }


### PR DESCRIPTION
**Type of change**

- [ ] New feature
- [X] Bug fix
- [X] Security patch
- [ ] Documentation update

**Description**

Adds a test for leap-year check.  
Changed date parsing implementation in date check to LocalDate.
Updated error message for errors that have to do with dates.

**Motivation**

Fixes a potential vulnerability where `valid` would return true on dates which are not valid (out of range).

**Checklist**

- [X] I have read the **CONTRIBUTING** document.
- [X] I have read and accepted the **Code of conduct**
- [X] Tests passes.
- [X] Style lints passes.
- [X] New tests added which covers the added code.
