### PR TITLE
fix: Fixed javadocs to show the actual long format (without separator).

### DIFF
--- a/src/main/java/dev/personnummer/Personnummer.java
+++ b/src/main/java/dev/personnummer/Personnummer.java
@@ -203,7 +203,7 @@ public final class Personnummer implements Comparable<Personnummer> {
 
     /**
      * Format the personal identity number into a valid string (YYMMDD-/+XXXX)
-     * If longFormat is true, it will include the century (YYYYMMDD-/+XXXX)
+     * If longFormat is true, it will include the century (YYYYMMDDXXXX)
      *
      * @return Formatted personal identity number.
      */
@@ -213,7 +213,7 @@ public final class Personnummer implements Comparable<Personnummer> {
 
     /**
      * Format the personal identity number into a valid string (YYMMDD-/+XXXX)
-     * If longFormat is true, it will include the century (YYYYMMDD-/+XXXX)
+     * If longFormat is true, it will include the century (YYYYMMDDXXXX)
      *
      * @param longFormat If century should be included.
      * @return Formatted personal identity number.


### PR DESCRIPTION
**Type of change**

- [ ] New feature
- [X] Bug fix
- [ ] Security patch
- [X] Documentation update

**Description**

Fixes javadocs which shows wrong format on long format output.

**Related issue**

#113 

**Motivation**

To stick to standard!

**Checklist**

- [X] I have read the **CONTRIBUTING** document.
- [X] I have read and accepted the **Code of conduct**
- [X] Tests passes.
- [X] Style lints passes.